### PR TITLE
changing default llm from sonnet to llama

### DIFF
--- a/variables.yml
+++ b/variables.yml
@@ -37,7 +37,7 @@ variables:
     default: false 
   model:
     description: LLM endpoint used by model calls. Note that this is not the same as any registered model in UC that wraps the prompt engineering work, but is the serving endpoint called after prompt engineering. This can be changed to other served models as well as provisioned throughput models or external models for compliance purposes if needed. Recommend databricks-claude-3-7-sonnet for best comments, with databricks-meta-llama-3-3-70b-instruct as a backup. Sonnet will generally give more complex responses. Review security, tenancy, and cost considerations before making a decision. 
-    default: databricks-claude-3-7-sonnet
+    default: databricks-meta-llama-3-3-70b-instruct
   job_table_names:
     description: default table names - get applied if there are no host overrides.
     default: default.simple_test


### PR DESCRIPTION
Primary reason for change is that sonnet seems to like injecting single quotes which llama does not seem to do as often.